### PR TITLE
Fix handling of External API formats

### DIFF
--- a/modules/external-api/src/main/java/org/opencastproject/external/common/ApiMediaType.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/common/ApiMediaType.java
@@ -51,16 +51,16 @@ public final class ApiMediaType {
 
   private static ApiFormat extractFormat(String mediaType) {
     final String subtype = extractSubtype(mediaType);
-    final String format;
     if (subtype.contains("+")) {
-      format = subtype.substring(subtype.indexOf("+") + 1);
-    } else if ("*".equals(subtype)) {
-      return ApiFormat.DEFAULT_API_FORMAT;
+      final String format = subtype.substring(subtype.indexOf("+") + 1);
+      try {
+        return ApiFormat.valueOf(format.toUpperCase());
+      } catch (Exception e) {
+        throw ApiMediaTypeException.invalidFormat(mediaType);
+      }
     } else {
-      format = subtype;
+      return ApiFormat.DEFAULT_API_FORMAT;
     }
-
-    return ApiFormat.valueOf(format.toUpperCase());
   }
 
   private static String extractSubtype(String mediaType) {

--- a/modules/external-api/src/main/java/org/opencastproject/external/common/ApiMediaTypeException.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/common/ApiMediaTypeException.java
@@ -28,6 +28,10 @@ public final class ApiMediaTypeException extends RuntimeException {
     return new ApiMediaTypeException("'" + mediaType + "' does not contain a valid version");
   }
 
+  public static ApiMediaTypeException invalidFormat(String mediaType) {
+    return new ApiMediaTypeException("'" + mediaType + "' does not contain a valid format");
+  }
+
   private ApiMediaTypeException(String message) {
     super(message);
   }


### PR DESCRIPTION
The REST API Docs is not "External API aware" and will send accept headers like "text/plain \*/\*" which caused an exception in the External API.

As the handling of formats is not in scope of the PR, I've added a correction that fits into the current design but also two JIRA issues:

- https://opencast.jira.com/browse/MH-12801 is about whether it might sense to remove the support for multiple formats in future work
- https://opencast.jira.com/browse/MH-12802 is about whether to correctly support content negotiation (currently not the case) or not