### PR TITLE
Make RestQuery 'workflowProperties' work with RestDocs

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventWorkflowPropertiesResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventWorkflowPropertiesResource.js
@@ -22,15 +22,18 @@
 
 angular.module('adminNg.resources')
 .factory('EventWorkflowPropertiesResource', ['$resource', function ($resource) {
-    var transform = function (data) {
-
-        var result = JSON.parse(data);
-
-        return result;
-
-    };
-
     return $resource('/admin-ng/event/workflowProperties', {}, {
-        get: { method: 'POST', isArray: false, transformRequest: function (data) {  return JSON.stringify(data); }, transformResponse: transform }
+        get: {
+          method: 'POST',
+          responseType: 'json',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          isArray: false,
+          transformRequest: function (data) {
+            return $.param({
+              eventIds : JSON.stringify(data)
+            });
+          }
+        }
+        
     });
 }]);


### PR DESCRIPTION
Hi @pmiddend 

This first PR ensures that /events/workflowProperties works with the RESTdocs by introducing 'eventIds' as form parameter.
It also renames a variable to be 120 characters per line.