### PR TITLE
Improve configurable publication service

### DIFF
--- a/etc/workflows/publish.xml
+++ b/etc/workflows/publish.xml
@@ -83,12 +83,19 @@
       id="defaults"
       description="Applying default configuration values">
       <configurations>
+        <configuration key="flagForCutting">false</configuration>
+        <configuration key="flagForReview">false</configuration>
+        <configuration key="flagQuality360p">false</configuration>
+        <configuration key="flagQuality480p">false</configuration>
+        <configuration key="flagQuality720p">true</configuration>
+        <configuration key="flagQuality1080p">false</configuration>
+        <configuration key="flagQuality2160p">false</configuration>
         <configuration key="publishToEngage">true</configuration>
         <configuration key="publishToApi">true</configuration>
         <configuration key="publishToOaiPmh">true</configuration>
         <configuration key="publishToYouTube">false</configuration>
         <configuration key="publishToAws">false</configuration>
-        <configuration key="flagMultiQuality">false</configuration>
+        <configuration key="uploadedSearchPreview">false</configuration>
         <configuration key="thumbnailType">0</configuration>
       </configurations>
     </operation>

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/TasksEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/TasksEndpoint.java
@@ -31,9 +31,15 @@ import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static org.opencastproject.index.service.util.RestUtils.okJson;
+import static org.opencastproject.systems.OpencastConstants.WORKFLOW_PROPERTIES_NAMESPACE;
 import static org.opencastproject.workflow.api.ConfiguredWorkflow.workflow;
 
 import org.opencastproject.assetmanager.api.AssetManager;
+import org.opencastproject.assetmanager.api.Property;
+import org.opencastproject.assetmanager.api.Value;
+import org.opencastproject.assetmanager.api.query.AQueryBuilder;
+import org.opencastproject.assetmanager.api.query.ARecord;
+import org.opencastproject.assetmanager.api.query.AResult;
 import org.opencastproject.assetmanager.util.Workflows;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.util.RestUtil;
@@ -182,6 +188,17 @@ public class TasksEndpoint {
         }
       }
     }
+    // FIXME: Only for testing purposes, delete before PR!
+    final AQueryBuilder q = assetManager.createQuery();
+    final String mpId = (String) eventIds.get(0);
+    final AResult r = q.select(q.snapshot(), q.propertiesOf(WORKFLOW_PROPERTIES_NAMESPACE))
+      .where(q.mediaPackageId(mpId).and(q.version().isLatest())).run();
+    for (final ARecord record : r.getRecords().toList()) {
+      for (final Property prop : record.getProperties().toList()) {
+        configuration.put(prop.getId().getName(), prop.getValue().get(Value.STRING));
+      }
+    }
+      // FIXME: Snippet end
 
     WorkflowDefinition wfd;
     try {

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/impl/ThumbnailImpl.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/impl/ThumbnailImpl.java
@@ -96,7 +96,6 @@ public final class ThumbnailImpl {
 
     ThumbnailSource(final long number) {
       this.number = number;
-
     }
 
     public long getNumber() {
@@ -126,15 +125,19 @@ public final class ThumbnailImpl {
     }
 
     public OptionalDouble getPosition() {
-      if (position == null)
+      if (position != null) {
+        return OptionalDouble.of(position);
+      } else {
         return OptionalDouble.empty();
-      return OptionalDouble.of(position);
+      }
     }
 
     public Optional<String> getTrack() {
-      if (track == null)
+      if (track != null) {
+        return Optional.of(track);
+      } else {
         return Optional.empty();
-      return Optional.of(track);
+      }
     }
 
     public URI getUrl() {
@@ -191,20 +194,23 @@ public final class ThumbnailImpl {
 
   private Optional<Attachment> getThumbnailPreviewForMediaPackage(final MediaPackage mp) {
     final Optional<Publication> internalPublication = getPublication(mp, InternalPublicationChannel.CHANNEL_ID);
-    if (!internalPublication.isPresent()) {
+    if (internalPublication.isPresent()) {
+      return Arrays
+        .stream(internalPublication.get().getAttachments())
+        .filter(attachment -> previewFlavor.matches(attachment.getFlavor()))
+        .findFirst();
+    } else {
       throw new IllegalStateException("Expected internal publication, but found none for mp " + mp.getIdentifier());
     }
-    return Arrays
-      .stream(internalPublication.get().getAttachments())
-      .filter(attachment -> previewFlavor.matches(attachment.getFlavor()))
-      .findFirst();
   }
 
-  public Optional<Thumbnail> getThumbnail(final MediaPackage mp, final UrlSigningService urlSigningService, final Long expireSeconds)
-    throws UrlSigningException, URISyntaxException {
+  public Optional<Thumbnail> getThumbnail(final MediaPackage mp, final UrlSigningService urlSigningService,
+        final Long expireSeconds) throws UrlSigningException, URISyntaxException {
+
     final Optional<Attachment> optThumbnail = getThumbnailPreviewForMediaPackage(mp);
-    if (!optThumbnail.isPresent())
+    if (!optThumbnail.isPresent()) {
       return Optional.empty();
+    }
     final Attachment thumbnail = optThumbnail.get();
     final URI url;
     if (urlSigningService.accepts(thumbnail.getURI().toString())) {
@@ -279,10 +285,11 @@ public final class ThumbnailImpl {
         .orElse(Arrays.stream(mp.getTracks(defaultTrackSecondary)).findFirst()
           .orElse(null)));
 
-    if (!track.isPresent()) {
+    if (track.isPresent()) {
+      return track.get();
+    } else {
       throw new MediaPackageException("Cannot find stream with primary or secondaŕy default flavor.");
     }
-    return track.get();
   }
 
   private void archive(final MediaPackage mp) {
@@ -323,12 +330,14 @@ public final class ThumbnailImpl {
     final URI publishThumbnailUri = workspace
       .put(mp.getIdentifier().compact(), publishThumbnailId, this.tempThumbnailFileName, inputStream);
     inputStream.close();
+
     final Attachment publishAttachment = AttachmentImpl.fromURI(publishThumbnailUri);
     publishAttachment.setIdentifier(UUID.randomUUID().toString());
     publishAttachment.setFlavor(publishFlavor.applyTo(trackFlavor));
     publishTags.forEach(publishAttachment::addTag);
     publishAttachment.setMimeType(this.tempThumbnailMimeType);
     publicationsToUpdate.add(publishAttachment);
+
     flavorsToRetract.add(publishFlavor);
     final long replaceStart = System.currentTimeMillis();
     final Job publishJob = oaiPmhPublicationService.replace(mp, oaiPmhChannel, publicationsToUpdate,
@@ -344,9 +353,10 @@ public final class ThumbnailImpl {
   }
 
   private Tuple<URI, MediaPackageElement> updatePublication(final MediaPackage mp, final String channelId,
-    final Predicate<Attachment> priorFilter, final MediaPackageElementFlavor flavor, final Collection<String> tags, final String conversionProfile)
-    throws DistributionException, NotFoundException, IOException, MediaPackageException, PublicationException,
-    EncoderException {
+    final Predicate<Attachment> priorFilter, final MediaPackageElementFlavor flavor, final Collection<String> tags,
+    final String conversionProfile) throws DistributionException, NotFoundException, IOException,
+  MediaPackageException, PublicationException, EncoderException {
+
     final Optional<Publication> pubOpt = getPublication(mp, channelId);
     if (!pubOpt.isPresent()) {
       return null;
@@ -357,19 +367,19 @@ public final class ThumbnailImpl {
     final InputStream inputStream = tempInputStream();
     final URI aUri = workspace.put(mp.getIdentifier().compact(), aid, tempThumbnailFileName, inputStream);
     inputStream.close();
-    final Attachment a = AttachmentImpl.fromURI(aUri);
-    a.setIdentifier(aid);
-    a.setFlavor(flavor);
-    tags.forEach(a::addTag);
-    a.setMimeType(tempThumbnailMimeType);
+    final Attachment attachment = AttachmentImpl.fromURI(aUri);
+    attachment.setIdentifier(aid);
+    attachment.setFlavor(flavor);
+    tags.forEach(attachment::addTag);
+    attachment.setMimeType(tempThumbnailMimeType);
     if (conversionProfile != null) {
-      downscaleAttachment(conversionProfile, a);
+      downscaleAttachment(conversionProfile, attachment);
     }
 
-    final Collection<MediaPackageElement> addElements = Collections.singleton(a);
-    final Collection<String> removeElements = Arrays.stream(pub.getAttachments()).filter(priorFilter)
-      .map(MediaPackageElement::getIdentifier).collect(Collectors.toList());
-    final Publication newPublication = replaceIgnoreExceptions(mp, channelId, addElements, removeElements);
+    final Collection<MediaPackageElement> addElements = Collections.singleton(attachment);
+    final Set<String> removeElementsIds = Arrays.stream(pub.getAttachments()).filter(priorFilter)
+      .map(MediaPackageElement::getIdentifier).collect(Collectors.toSet());
+    final Publication newPublication = replaceIgnoreExceptions(mp, channelId, addElements, removeElementsIds);
     mp.remove(pub);
     mp.add(newPublication);
     //noinspection ConstantConditions
@@ -378,16 +388,16 @@ public final class ThumbnailImpl {
     return Tuple.tuple(aUri, newElement);
   }
 
-  private void downscaleAttachment(final String conversionProfile, final Attachment a)
+  private void downscaleAttachment(final String conversionProfile, final Attachment attachment)
     throws EncoderException, MediaPackageException, DistributionException {
-    final Job conversionJob = composerService.convertImage(a,conversionProfile);
+    final Job conversionJob = composerService.convertImage(attachment, conversionProfile);
     if (!waitForJob(serviceRegistry, conversionJob).isSuccess()) {
       throw new DistributionException("Image downscaling did not work");
     }
     // What the composer returns is not our original attachment, modified, but a new one, basically containing just
     // a URI.
     final Attachment downscaled = (Attachment) MediaPackageElementParser.getFromXml(conversionJob.getPayload());
-    a.setURI(downscaled.getURI());
+    attachment.setURI(downscaled.getURI());
   }
 
   private URI updateExternalPublication(final MediaPackage mp, final MediaPackageElementFlavor trackFlavor)
@@ -399,9 +409,11 @@ public final class ThumbnailImpl {
     final Predicate<Attachment> priorFilter = flavorFilter.and(tagsFilter);
     final Tuple<URI, MediaPackageElement> result = updatePublication(mp, "api", priorFilter,
       publishFlavor.applyTo(trackFlavor), publishTags, null);
-    if (result == null)
+    if (result != null) {
+      return result.getA();
+    } else {
       return null;
-    return result.getA();
+    }
   }
 
   private InputStream tempInputStream() throws NotFoundException, IOException {
@@ -441,16 +453,16 @@ public final class ThumbnailImpl {
   }
 
   private Publication replaceIgnoreExceptions(final MediaPackage mp, final String channelId,
-    final Collection<? extends MediaPackageElement> addElementIds, final Collection<String> retractElementIds)
+    final Collection<? extends MediaPackageElement> addElements, final Set<String> retractElementIds)
     throws DistributionException, MediaPackageException, PublicationException {
 
-    final Job j = this.configurablePublicationService.replace(mp, channelId, addElementIds, retractElementIds);
+    final Job job = this.configurablePublicationService.replace(mp, channelId, addElements, retractElementIds);
 
-    if (!waitForJob(serviceRegistry, j).isSuccess()) {
+    if (!waitForJob(serviceRegistry, job).isSuccess()) {
       throw new DistributionException("At least one of the retraction jobs did not complete successfully");
     }
 
-    return (Publication) MediaPackageElementParser.getFromXml(j.getPayload());
+    return (Publication) MediaPackageElementParser.getFromXml(job.getPayload());
   }
 
   private MediaPackageElement chooseThumbnail(final MediaPackage mp, final Track track, final double position)

--- a/modules/publication-service-api/src/main/java/org/opencastproject/publication/api/ConfigurablePublicationService.java
+++ b/modules/publication-service-api/src/main/java/org/opencastproject/publication/api/ConfigurablePublicationService.java
@@ -27,10 +27,29 @@ import org.opencastproject.mediapackage.MediaPackageElement;
 import org.opencastproject.mediapackage.MediaPackageException;
 
 import java.util.Collection;
+import java.util.Set;
 
 public interface ConfigurablePublicationService {
+
   String JOB_TYPE = "org.opencastproject.publication.configurable";
 
+  /**
+   * Replaces media package elements.
+   * 
+   * @param mediaPackage
+   *          the media package
+   * @param channelId
+   *          the id of the publication channel
+   * @param addElements
+   *          the media package elements to be added
+   * @param rectractElementIds
+   *          the ids of the media package elements to be removed
+   * @return The job
+   * @throws PublicationException
+   *           if there was a problem publishing the media
+   * @throws MediaPackageException
+   *           if there was a problem with the mediapackage element
+   */
   Job replace(MediaPackage mediaPackage, String channelId, Collection<? extends MediaPackageElement> addElements,
-          Collection<String> retractElementIds) throws PublicationException, MediaPackageException;
+          Set<String> retractElementIds) throws PublicationException, MediaPackageException;
 }

--- a/modules/publication-service-configurable-remote/pom.xml
+++ b/modules/publication-service-configurable-remote/pom.xml
@@ -26,6 +26,10 @@
       <artifactId>commons-io</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+    </dependency>
+    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
     </dependency>

--- a/modules/publication-service-configurable/pom.xml
+++ b/modules/publication-service-configurable/pom.xml
@@ -31,6 +31,10 @@
       <artifactId>commons-io</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+    </dependency>
+    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
     </dependency>

--- a/modules/publication-service-configurable/src/main/resources/OSGI-INF/publication-service-configurable.xml
+++ b/modules/publication-service-configurable/src/main/resources/OSGI-INF/publication-service-configurable.xml
@@ -26,12 +26,12 @@
                cardinality="1..1"
                policy="static"
                bind="setOrganizationDirectoryService" />
-    <reference name="distributionService"
+    <reference name="DownloadDistributionService"
                interface="org.opencastproject.distribution.api.DownloadDistributionService"
                cardinality="1..1"
                policy="static"
                target="(distribution.channel=download)"
-               bind="setDistributionService" />
+               bind="setDownloadDistributionService" />
   </scr:component>
 
    <scr:component name="org.opencastproject.publication.configurable.endpoint.ConfigurablePublicationRestService" immediate="true">


### PR DESCRIPTION
This pull request addresses the following issues:

- Replaced custom code (un-)marshalling by GSON (depending on the reviewer, the custom code would not pass)
- Always use curly braces code blocks of if statements (there is a proposal ongoing to enforce this using checkstyle)
- Sometimes lines were longer than max 120 characters
- Use Set (instead of Collection) for retracted element ids. This avoids having to deal with duplicates and is more consistent with the distribution service API
- Use DownloadDistributionService directly to have access to the bulk distribution API