### PR TITLE
Improve usability of deleting series with events

### DIFF
--- a/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
@@ -52,8 +52,6 @@
          "UNKNOWN"            : "The following element will be deleted",
          "EVENT"              : "The following event will be deleted",
          "SERIES"             : "The following series will be deleted",
-         "SERIES_WITH_EVENTS" : "The series still contains events",
-         "SERIES_WITH_EVENTS_DELETE_NOT_ALLOWED" : "Deleting series containing events is not allowed",
          "ACL"                : "The following ACL will be deleted",
          "GROUP"              : "The following group will be deleted",
          "USER"               : "The following user will be deleted",
@@ -66,7 +64,13 @@
        "NAME" : "Name"
      },
      "ACTIONS": {
-       "CONFIRMATION" : "Confirmation required"
+       "CONFIRMATION" : "Confirmation"
+     },
+     "WARNINGS": {
+       "SERIES_HAS_EVENTS": "This series does contain events. Deleting the series will not delete the events"
+     },
+     "ERRORS": {
+       "SERIES_HAS_EVENTS": "This series cannot be deleted as it still contains events"
      }
    },
    "MEDIAMODULE": "Media Module",
@@ -195,7 +199,8 @@
       "DELETE": {
           "SERIES": {
             "CAPTION": "Delete",
-            "BUTTON": "Delete"
+            "BUTTON": "Delete",
+            "CANNOT_DELETE": "The highlighted series cannot be deleted as they still contain events."
           },
           "EVENTS": {
             "CAPTION": "Delete",

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/delete-series-modal.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/delete-series-modal.html
@@ -8,7 +8,7 @@
 
         <div class="modal-body">
 
-            <div class="modal-alert danger">
+            <div class="modal-alert danger obj">
                 <p translate="BULK_ACTIONS.DELETE_SERIES_WARNING_LINE1">
                     <!-- You have chosen to delete a series. Once deleted all metadata will be deleted
                          and can not be retrieved. -->
@@ -18,6 +18,12 @@
                 </p>
             </div>
 
+            <div ng-show="!allowed()" class="alert sticky warning">
+              <p translate="BULK_ACTIONS.DELETE.SERIES.CANNOT_DELETE">
+                <!-- The highlighted series cannot be deleted as they still contain events -->
+              </p>
+            </div>
+
             <div class="full-col">
                 <div class="obj">
                     <header translate="EVENTS.SERIES.TABLE.CAPTION"><!-- Series --></header>
@@ -25,15 +31,19 @@
                         <table class="main-tbl">
                             <thead>
                                 <tr>
-                                    <th class="small"><input type="checkbox" ng-model="allSelected" ng-change="allSelectedChanged()" class="select-all-cbox"></th>
+                                    <th class="small">
+                                      <input type="checkbox" ng-model="allSelected" ng-change="allSelectedChanged()" class="select-all-cbox">
+                                    </th>
                                     <th translate="EVENTS.SERIES.TABLE.TITLE"><!-- Series --></th>
                                     <th translate="EVENTS.SERIES.TABLE.CREATORS"><!-- Organizer(s) --></th>
                                     <th translate="EVENTS.SERIES.TABLE.HAS_EVENTS"><!-- Has events --></th>
                                 </tr>
                             </thead>
                             <tbody>
-                                <tr ng-repeat="row in rows">
-                                    <td><input type="checkbox" ng-model="row.selected" ng-change="rowSelectionChanged($index)" class="child-cbox"></td>
+                                <tr ng-repeat="row in rows" ng-class="{error: !deleteSeriesWithEventsAllowed && row.selected && row.hasEvents}">
+                                    <td>
+                                      <input type="checkbox" ng-model="row.selected" ng-change="rowSelectionChanged($index)" class="child-cbox">
+                                    </td>
                                     <td>{{ row.title }}</td>
                                     <td>{{ row.creator }}</td>
                                     <td ng-class="row.hasEvents == true ? 'fa fa-check' : ''"></td>

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/delete-single-series-modal.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/delete-single-series-modal.html
@@ -1,23 +1,44 @@
 <section ng-show="open" ng-keyup="keyUp($event)" tabindex="1" class="modal modal-animation ng-hide" id="delete-single-series-modal">
+   
     <header>
         <a class="fa fa-times close-modal" ng-click="close()"></a>
-        <h2 translate="CONFIRMATIONS.ACTIONS.CONFIRMATION"><!-- Confirm --></h2>
+        <h2 translate="CONFIRMATIONS.ACTIONS.CONFIRMATION"><!-- Confirmation  --></h2>
     </header>
 
-    <div>
-        <p><span translate="CONFIRMATIONS.METADATA.NOTICE.SERIES"><!-- The following series will be deleted --></span>:</p>
-        <p class="delete">{{name}}</p>
-    </div>
-    <div ng-if="hasEvents == true">
-        <p><span translate="CONFIRMATIONS.METADATA.NOTICE.SERIES_WITH_EVENTS"><!-- The series contains events --></span></p>
-    </div>
     <div ng-if="hasEvents == true && deleteSeriesWithEventsAllowed == false">
-        <p><span translate="CONFIRMATIONS.METADATA.NOTICE.SERIES_WITH_EVENTS_DELETE_NOT_ALLOWED"><!-- The series contains events --></span></p>
+      <div class="modal-alert danger">
+        <p translate="CONFIRMATIONS.ERRORS.SERIES_HAS_EVENTS">
+          <!-- The highlighted series cannot be deleted as they still contain events -->
+        </p>
+      </div>
+      <div class="btn-container">
+          <a translate="CANCEL" class="cancel-btn close-modal" ng-click="close()">
+            <!--- Cancel -->
+          </a>
+      </div>
     </div>
-    <p translate="CONFIRMATIONS.CONTINUE_ACTION"><!-- Are you sure you want to continue? --></p>
 
-    <div class="btn-container">
-        <a translate="CANCEL" class="cancel-btn close-modal" ng-click="close()"><i><!--- Cancel --></i></a>
-        <a ng-if="hasEvents == false || hasEvents == true && deleteSeriesWithEventsAllowed == true" translate="CONFIRM" class="danger-btn" ng-click="confirm()"><i><!-- Confirm --></i></a>
+    <div ng-if="hasEvents == false || deleteSeriesWithEventsAllowed == true">
+
+      <div ng-if="hasEvents == true && deleteSeriesWithEventsAllowed == true" class="modal-alert warning">
+        <p translate="CONFIRMATIONS.WARNINGS.SERIES_HAS_EVENTS">
+          <!-- The highlighted series cannot be deleted as they still contain events -->
+        </p>
+      </div>
+
+      <div>
+          <p><span translate="CONFIRMATIONS.METADATA.NOTICE.SERIES"><!-- The following series will be deleted --></span>:</p>
+          <p class="delete">{{name}}</p>
+      </div>
+      <p translate="CONFIRMATIONS.CONTINUE_ACTION"><!-- Are you sure you want to continue? --></p>
+
+      <div class="btn-container">
+          <a translate="CANCEL" class="cancel-btn close-modal" ng-click="close()">
+            <!--- Cancel -->
+          </a>
+          <a translate="CONFIRM" class="danger-btn" ng-click="confirm()">
+            <!-- Confirm -->
+          </a>
+      </div>
     </div>
 </section>


### PR DESCRIPTION
Hi @doofy 

This pull request aims at improving the usability in the following ways:

- Bulk series deletion now has similar look & feel as bulk events deletion, e.g. show a warning that some highlighted series cannot be deleted and highlight them
- Single deletion has 3 cases now: a) series has no events: same as before, b) series has events and allowed to delete: show warning and c) series has events and don't allow deletion: Show error but nothing else
