### PR TITLE
Fix layout of thumbnail preview and button spacing

### DIFF
--- a/modules/admin-ui/src/main/webapp/styles/components/video/_video-editor.scss
+++ b/modules/admin-ui/src/main/webapp/styles/components/video/_video-editor.scss
@@ -771,6 +771,7 @@ $segment-deleted-selected: darken($segment-deleted, 18%);
 
   form {
     display: inline;
+    margin-left: 6px;
   }
 
   .controls {
@@ -790,6 +791,7 @@ $segment-deleted-selected: darken($segment-deleted, 18%);
     margin: 20px;
     width: 320px;
     height: 180px;
+    min-width: 320px;
     background-size: contain;
     background-repeat: no-repeat;
     background-position: center center;


### PR DESCRIPTION
Hi @krinnewitz When doing screenshots, I've found two minor layout problems: The thumbnail preview box should really be fixed size (it did get smaller when changing the browser window size) and the spacing between the buttons was not correct.